### PR TITLE
fix: add Chrome/ium fallback for getBrowserInfo()

### DIFF
--- a/EnvironmentalOptions.js
+++ b/EnvironmentalOptions.js
@@ -15,10 +15,10 @@
 /**
  * Returns whether the current runtime is a mobile one (true) or not (false).
  *
- * @private
+ * @public
  * @returns {Promise<bool>}
  */
-async function isMobile() {
+ export async function isMobile() {
     const platformInfo = await browser.runtime.getPlatformInfo();
 
     return platformInfo.os === "android";
@@ -29,10 +29,10 @@ async function isMobile() {
 *
 *  This includes Firefox and Thunderbird e.g.
 *
-* @private
+* @public
 * @returns {Promise<bool>}
 */
-async function isMozilla() {
+export async function isMozilla() {
     const browserInfo = await browser.runtime.getBrowserInfo();
 
     // Thunderbird is explicitly checked as a workaround as Thunderbird does not return the vendor correctly
@@ -46,10 +46,10 @@ async function isMozilla() {
 *
 *  This does not include Thunderbird!
 *
-* @private
+* @public
 * @returns {Promise<bool>}
 */
-async function isFirefox() {
+export async function isFirefox() {
     const browserInfo = await browser.runtime.getBrowserInfo();
 
     return browserInfo.name === "Firefox";

--- a/EnvironmentalOptions.js
+++ b/EnvironmentalOptions.js
@@ -13,6 +13,23 @@
  */
 
 /**
+ * Return the browser's browser info or fallback to an empty object.
+ *
+ * This is a workaround for Chrome/ium browsers that do not support runtime.getBrowserInfo().
+ * See https://github.com/TinyWebEx/AutomaticSettings/issues/18
+ *
+ * @private
+ * @returns {Promise<bool>}
+ */
+async function getBrowserInfo() {
+    if (!browser.runtime.getBrowserInfo) {
+        return {};
+    }
+
+    return await browser.runtime.getBrowserInfo();
+}
+
+/**
  * Returns whether the current runtime is a mobile one (true) or not (false).
  *
  * @public
@@ -33,7 +50,7 @@
 * @returns {Promise<bool>}
 */
 export async function isMozilla() {
-    const browserInfo = await browser.runtime.getBrowserInfo();
+    const browserInfo = await getBrowserInfo();
 
     // Thunderbird is explicitly checked as a workaround as Thunderbird does not return the vendor correctly
     // see https://bugzilla.mozilla.org/show_bug.cgi?id=1702722
@@ -50,7 +67,7 @@ export async function isMozilla() {
 * @returns {Promise<bool>}
 */
 export async function isFirefox() {
-    const browserInfo = await browser.runtime.getBrowserInfo();
+    const browserInfo = await getBrowserInfo();
 
     return browserInfo.name === "Firefox";
 }

--- a/tests/environmentalOptions.test.js
+++ b/tests/environmentalOptions.test.js
@@ -1,0 +1,31 @@
+import "https://unpkg.com/mocha@5.2.0/mocha.js"; /* globals mocha */
+import "https://unpkg.com/chai@4.1.2/chai.js"; /* globals chai */
+import "https://unpkg.com/sinon@6.1.5/pkg/sinon.js"; /* globals sinon */
+
+import * as EnvironmentalOptions from "../EnvironmentalOptions.js";
+
+describe("options module: AutomaticSettings.EnvironmentalOptions", function () {
+    describe("isMobile()", function () {
+        it("returns true as browser is a mobile browser", async function () {
+            const result = await EnvironmentalOptions.isMobile();
+
+            chai.assert.isTrue(result);
+        });
+    });
+
+    describe("isMozilla()", function () {
+        it("returns true as browser is a Mozilla browser", async function () {
+            const result = await EnvironmentalOptions.isMozilla();
+
+            chai.assert.isTrue(result);
+        });
+    });
+
+    describe("isFirefox()", function () {
+        it("returns true as browser is a Mozilla Firefox", async function () {
+            const result = await EnvironmentalOptions.isFirefox();
+
+            chai.assert.isTrue(result);
+        });
+    });
+});

--- a/tests/run.js
+++ b/tests/run.js
@@ -2,6 +2,7 @@ import "https://unpkg.com/mocha@5.2.0/mocha.js"; /* globals mocha */
 
 /* tests */
 import "./automaticSettings.test.js";
+import "./environmentalOptions.test.js";
 
 mocha.checkLeaks();
 mocha.run();

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,4 +1,5 @@
 import "https://unpkg.com/mocha@5.2.0/mocha.js"; /* globals mocha */
+import "https://unpkg.com/webextension-polyfill@0.8.0/dist/browser-polyfill.js"
 // import "./node_modules/sinon/pkg/sinon.js";
 
 mocha.setup("bdd");


### PR DESCRIPTION
Note that:
* Yes, these added tests fail. You can anyway only manually run them for now, but they are useful enough in this way to test if . (The old ones are broken anyway, if someone cares to fix them, feel free to do so. :thinking: )
  See https://github.com/TinyWebEx/common/blob/master/CONTRIBUTING.md#tests on how to run these.
* Also, the tests are made to always assume `true`. If you know any way to exclude tests to run on certain browsers with mocha, feel free to change/suggest it to me. Otherwise, as said, let*'s just keep them as such.
  It's just easier to test this way (did so in Chrome/ium) than to keep watching for console messages or even CSS classes. 
* Also I had to export all these functions, but really… they are actually useful if one wants to use them as they are.

Also I just noticed it would be useful to move that JS file to https://github.com/TinyWebEx/EnvironmentDetector (maybe name it `SystemDetector` or so) and include it as a dependency here, as that is much more useful.

IIRC `EnvironmentDetector` worked roughly, but I was never quite convinced of it and thus did not use it yet. But sure we can make use of the simple functions here if we move them there.

Fixes https://github.com/TinyWebEx/AutomaticSettings/issues/18